### PR TITLE
Option to not fetch candidates without photometry

### DIFF
--- a/scripts/get-des-lightcurves
+++ b/scripts/get-des-lightcurves
@@ -241,12 +241,16 @@ def parse_args():
         print "Table must be one of: " + ",".join(TABLES)
         sys.exit(1)
 
+    if opts.hasphot and opts.table == 'snobs':
+        print 'Cannot stipulate hasphot when table==snobs.'
+        sys.exit(1)
+
     opts.format = opts.format.lower()
     if opts.format == 'csv': opts.format = 'ascii'  # backwards compatibility
     if opts.format not in FORMATS:
         print "Format must be one of:", ', '.join(FORMATS)
         sys.exit(1)
-
+    
     # Check output, depending on format
     if opts.format == 'fits':
         import fitsio   # fail immediately if fitsio not installed
@@ -268,6 +272,8 @@ def parse_args():
     opts.bandnames = {'g': names[0],'r': names[1],'i': names[2],'z': names[3]}
 
     return snids, opts
+
+
 
 
 # Query string builders ==================================================== #


### PR DESCRIPTION
I want to resolve #3 by adding a command line option to `get-des-lightcurves` that enables one to only fetch light curves for entries in `SNCAND` that have corresponding entries in the desired photometry table. This was designed specifically to address the large number of candidates without Sullivan photometry that Ravi was having to process while trying to query the `SNPHOTMS` table, but it is a general filter and can be used for other candidate tables, photometry tables, and schemas. 

I also removed the `NUMEPOCHS_ML` condition for the `SNCAND_LEGACY` table, since `NUMEPOCHS_ML` in the `SNCAND_LEGACY` table is computed WRT a different ML version (1) than the `NUMEPOCHS_ML` columns in the `Y2PROD` and `Y1RE(RE)PROC`  (2), which may cause confusion. 
